### PR TITLE
Use only one db instance [breaking]

### DIFF
--- a/treestatsquery/treestatsquery.go
+++ b/treestatsquery/treestatsquery.go
@@ -1,6 +1,8 @@
 package treestatsquery
 
 import (
+	"fmt"
+
 	"github.com/ppenguin/filetypestats/ftsdb"
 	"github.com/ppenguin/filetypestats/types"
 )
@@ -27,5 +29,20 @@ func FTStatsSum(dbfile string, paths []string) (types.FileTypeStats, error) {
 	defer fdb.Close()
 
 	res, err := fdb.FTStatsSum(paths)
+	return res, err
+}
+
+func FTStatsSumDB(dbconn *ftsdb.FileTypeStatsDB, paths []string) (types.FileTypeStats, error) {
+	var err error
+	if dbconn == nil {
+		err = fmt.Errorf("invalid: dbconn==nil")
+	} else if !dbconn.IsOpened {
+		err = fmt.Errorf("dbconn is not open")
+	}
+	if err != nil {
+		return types.FileTypeStats{}, err
+	}
+
+	res, err := dbconn.FTStatsSum(paths)
 	return res, err
 }

--- a/treestatswatcher.go
+++ b/treestatswatcher.go
@@ -42,24 +42,17 @@ type TreeStatsWatcher struct {
 // An instance is always returned, even if an error occurred
 // dirs will be trimmed of trailing suffixes and evaluated recursively
 // If dirs is empty, you can add watches later with AddWatch() or AddDir()
-func NewTreeStatsWatcher(dirs []string, database string) (*TreeStatsWatcher, error) {
-	var fdb *ftsdb.FileTypeStatsDB
-	var err error
-	if database != "" {
-		fdb, err = ftsdb.New(database, true)
-	} else {
-		fdb = nil
-	}
+func NewTreeStatsWatcher(dirs []string, dbconn *ftsdb.FileTypeStatsDB) (*TreeStatsWatcher, error) {
 	tsw := &TreeStatsWatcher{
 		*NewDirMonitors(),
 		time.Duration(0),
 		make(tMoveMap),
-		fdb,
+		dbconn,
 		nil,
 		&sync.WaitGroup{},
 	}
 	tsw.eventHandler = tsw.onFileChanged // set default event handler
-	tsw.AddWatch(dirs...)
+	err := tsw.AddWatch(dirs...)
 	return tsw, err // always return a valid watcher instance, we can add dirs and use other features later
 }
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package filetypestats
 
 // Version exposes the current package version.
-const Version = "v0.5.0"
+const Version = "v0.6.0"


### PR DESCRIPTION
Use dbconnection as argument to `TreeStatsWatcher` and `FTStatSumDB` (query) so one program instance can (and should) use one database instance. (Otherwise you can get `database is locked` errors)